### PR TITLE
Response handling: Reproduce wrong response sent in some cases

### DIFF
--- a/MinimalApi.Tests.Integration/Tests/Example/GetExampleEndpointTests.cs
+++ b/MinimalApi.Tests.Integration/Tests/Example/GetExampleEndpointTests.cs
@@ -5,6 +5,28 @@ namespace MinimalApi.Tests.Integration.Tests.Example
     [Collection("Endpoint")]
     public class GetExampleEndpointTests(RadEndpointFixture f)
     {
+        // This test is implemented only to demonstrate an issue, and it is not meant to stay part of the suite.
+        [Fact]
+        public async void When_EndpointDoesNotUseSend_ReturnsCorrectResponse()
+        {
+            //Act            
+
+            // GetExampleEndpoint has a 'special' part of the code, which returns "Rando" as a First Name
+            // when ID is in the request set to 99. 
+            var r = await f.Client.GetAsync<GetExampleEndpoint, GetExampleRequest, GetExampleResponse>(new()
+            {
+                Id = 99
+            });
+
+            //Assert
+            r.Should().BeSuccessful<GetExampleResponse>();            
+          
+            // This assertion tries to assert that the name is Rando, as expected, but
+            // it wont be. This happens when endpoint does not use Send to response back, but
+            // the current implementation will send the Response back anyway.
+            r.Content.Data!.FirstName.Should().Be("Rando");
+        }
+        
         [Fact]
         public async void When_RequestValid_ReturnsSuccess()
         {

--- a/MinimalApi/Features/Examples/GetExample/GetExampleEndpoint.cs
+++ b/MinimalApi/Features/Examples/GetExample/GetExampleEndpoint.cs
@@ -1,4 +1,5 @@
 ﻿using MinimalApi.Domain.Examples;
+using MinimalApi.Features.Examples._common;
 
 namespace MinimalApi.Features.Examples.GetExample
 {
@@ -15,6 +16,24 @@ namespace MinimalApi.Features.Examples.GetExample
 
         public async override Task Handle(GetExampleRequest r, CancellationToken ct)
         {
+            // This condition is added only to demonstrate an issue. It is not meant to persists as a part of the
+            // codebase and/or test suite.
+            // ### START ###
+            if (r.Id == 99)
+            {
+                // Set the response data, but do not use Send() method to send the response.
+                // As per current implementation, RadEndpoint will send the response back.
+                // But, the current implementation will not send this particular Response instance, rather
+                // a different one - resulting in response that is not as expected.
+                Response.Data = new ExampleDto
+                {
+                    FirstName = "Rando"
+                };
+                
+                return;
+            }
+            // ### END ###
+            
             var result = await s.GetExample(r.Id);
 
             result.Switch


### PR DESCRIPTION
Note: This PR is just an observation, as this repo is still a prototype. It helps reproducing a small issue, but it is not meant to be merged.

When the endpoint does not use Send() to send the response, RadEndpoint still sends the response back, but a different instance of it, rather than the expected one. This causes Response to differ compared to what is done with it in the endpoint.

 - The issue of not using Send() is easy to make.

 - There are no compile time, or run time checks if it is not invoked.

 - Potential solutions:
   1. Require return value in the Handle method enforcing returning a response.
   2. Require response as a parameter of Send and not have Response as a premade instance. to make clar that Response somehow has to be sent back.
   3. Combine point #2 with an analyzer to provide compile time hint.